### PR TITLE
openssl: update to 1.0.2s

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.0.2
-PKG_BUGFIX:=r
+PKG_BUGFIX:=s
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:=http://www.openssl.org/source/ \
 	http://www.openssl.org/source/old/$(PKG_BASE)/ \
 	ftp://ftp.funet.fi/pub/crypt/mirrors/ftp.openssl.org/source \
 	ftp://ftp.sunet.se/pub/security/tools/net/openssl/source/
-PKG_HASH:=ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6
+PKG_HASH:=cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/openssl/patches/150-no_engines.patch
+++ b/package/libs/openssl/patches/150-no_engines.patch
@@ -1,6 +1,6 @@
 --- a/Configure
 +++ b/Configure
-@@ -2143,6 +2143,11 @@ EOF
+@@ -2144,6 +2144,11 @@ EOF
  	close(OUT);
    }
    


### PR DESCRIPTION
This avoids CVE-2019-9498 and CVE-2019-9499 in hostapd

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
[DMARC removal, refreshed patches]